### PR TITLE
Add API route to production server

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,5 +6,6 @@ const PORT = process.env.PORT || 5000;
 
 express()
   .use(express.static(path.join(__dirname, 'public')))
+  .all('/api/*', (req, res) => res.sendStatus(404))
   .get('*', (req, res) => res.sendFile(path.resolve(__dirname, 'public', 'index.html')))
   .listen(PORT, () => console.log(`Listening on ${PORT}`));


### PR DESCRIPTION
This commit adds a route to /api for the production server. This route
responds to all HTTP verbs with 404. This is done to fix the failing
production deployment, as a temporary measure until an actual API is in
place.

This fixes #5